### PR TITLE
Fix anime editing bug and scroll button visibility

### DIFF
--- a/main.js
+++ b/main.js
@@ -164,6 +164,7 @@ function setupEventListeners() {
             const animes = await api.getAnimesBySeason(state.currentSeasonId);
             ui.renderAnimes(animes);
             ui.closeModal(ui.DOM.addAnimeModal);
+            state.editingAnimeId = null; // Reset editing state
         } else {
             alert(`No se pudo ${state.editingAnimeId ? 'actualizar' : 'guardar'} el anime.`);
         }

--- a/style.css
+++ b/style.css
@@ -546,7 +546,7 @@ legend {
 .readonly-mode #season-manager #add-season-btn,
 .readonly-mode #season-manager #edit-season-btn,
 .readonly-mode #season-manager #delete-season-btn,
-.readonly-mode .fab,
+.readonly-mode #add-anime-btn,
 .readonly-mode .anime-actions {
     display: none !important;
 }


### PR DESCRIPTION
This commit addresses two issues:

1.  Fixes a bug where adding a new anime after editing an existing one would overwrite the edited anime. This was caused by the `editingAnimeId` not being reset in the application's state after a successful update. The fix resets the `editingAnimeId` to null after a save operation.

2.  Makes the "scroll to top" button visible for all users, not just administrators. The CSS rule for read-only mode was too broad, hiding all floating action buttons. The selector has been made more specific to only hide the "add anime" button.