### PR TITLE
This commit introduces a major new feature and fixes two outstanding …

### DIFF
--- a/api.js
+++ b/api.js
@@ -10,23 +10,106 @@ export const getSeasons = async () => {
 
 export const getAnimesBySeason = async (seasonId) => {
     if (!seasonId) return [];
-    const { data, error } = await _supabase
+
+    // 1. Fetch all anime entries for the season
+    const { data: animesInSeason, error: initialError } = await _supabase
         .from('animes')
-        .select('*, openings(*), endings(*)')
+        .select('*')
         .eq('season_id', seasonId)
         .order('created_at');
-    if (error) console.error('Error fetching animes:', error);
-    return data || [];
+
+    if (initialError) {
+        console.error('Error fetching animes for season:', initialError);
+        return [];
+    }
+
+    // 2. Process each anime to fetch correct songs/details
+    const processedAnimes = await Promise.all(animesInSeason.map(async (anime) => {
+        if (anime.main_anime_id) {
+            // It's a continuation, fetch details from the main anime
+            const { data: mainAnime, error: mainError } = await _supabase
+                .from('animes')
+                .select('name, comments, openings(*), endings(*)')
+                .eq('id', anime.main_anime_id)
+                .single();
+
+            if (mainError) {
+                console.error(`Error fetching main anime details for ${anime.id}:`, mainError);
+                return { ...anime, name: 'Error loading details' }; // Return gracefully
+            }
+
+            // Merge data: keep continuation's ID and day, but use main's details
+            return {
+                ...anime, // keeps original id, season_id, day_of_week, main_anime_id
+                name: mainAnime.name,
+                comments: mainAnime.comments,
+                openings: mainAnime.openings,
+                endings: mainAnime.endings,
+            };
+        } else {
+            // It's a main anime, just fetch its own songs
+            const { data: songs, error: songError } = await _supabase
+                .from('animes')
+                .select('openings(*), endings(*)')
+                .eq('id', anime.id)
+                .single();
+
+            if (songError) {
+                console.error(`Error fetching songs for ${anime.id}:`, songError);
+            }
+
+            return { ...anime, ...songs };
+        }
+    }));
+
+    return processedAnimes;
 };
 
 export const getAnimeDetails = async (animeId) => {
-    const { data, error } = await _supabase
+    const { data: anime, error } = await _supabase
         .from('animes')
-        .select('*, openings(*), endings(*)')
+        .select('*')
         .eq('id', animeId)
         .single();
-    if (error) console.error('Error fetching anime details:', error);
-    return data;
+
+    if (error) {
+        console.error('Error fetching anime details:', error);
+        return null;
+    }
+
+    if (anime.main_anime_id) {
+        // It's a continuation, get shared data from main
+        const { data: mainAnime, error: mainError } = await _supabase
+            .from('animes')
+            .select('name, comments, openings(*), endings(*)')
+            .eq('id', anime.main_anime_id)
+            .single();
+
+        if (mainError) {
+            console.error(`Error fetching main anime details for ${anime.id}:`, mainError);
+            return null;
+        }
+
+        return {
+            ...anime,
+            name: mainAnime.name,
+            comments: mainAnime.comments,
+            openings: mainAnime.openings,
+            endings: mainAnime.endings,
+        };
+    } else {
+        // It's a main anime, get its own songs
+        const { data: songs, error: songError } = await _supabase
+            .from('animes')
+            .select('openings(*), endings(*)')
+            .eq('id', anime.id)
+            .single();
+        if (songError) {
+            console.error(`Error fetching songs for ${anime.id}:`, songError);
+            return null;
+        }
+        return { ...anime, ...songs };
+    }
 };
 
 export const addSeason = async (name) => {
@@ -36,6 +119,20 @@ export const addSeason = async (name) => {
         return false;
     }
     return true;
+};
+
+export const getContinuableAnimes = async () => {
+    const { data, error } = await _supabase
+        .from('animes')
+        .select('id, name')
+        .is('main_anime_id', null)
+        .order('name', { ascending: true });
+
+    if (error) {
+        console.error('Error fetching continuable animes:', error);
+        return [];
+    }
+    return data || [];
 };
 
 export const updateSeason = async (id, name) => {
@@ -68,34 +165,61 @@ export const addAnime = async (animeData, openings, endings) => {
         return null;
     }
 
-    const animeId = newAnime.id;
-    if (openings.length > 0) {
-        const openingsWithId = openings.map(o => ({ ...o, anime_id: animeId }));
-        await _supabase.from('openings').insert(openingsWithId);
-    }
-    if (endings.length > 0) {
-        const endingsWithId = endings.map(e => ({ ...e, anime_id: animeId }));
-        await _supabase.from('endings').insert(endingsWithId);
+    // Only add songs if it's not a continuation entry
+    if (!newAnime.main_anime_id) {
+        const animeId = newAnime.id;
+        if (openings && openings.length > 0) {
+            const openingsWithId = openings.map(o => ({ ...o, anime_id: animeId }));
+            await _supabase.from('openings').insert(openingsWithId);
+        }
+        if (endings && endings.length > 0) {
+            const endingsWithId = endings.map(e => ({ ...e, anime_id: animeId }));
+            await _supabase.from('endings').insert(endingsWithId);
+        }
     }
     return newAnime;
 };
 
 export const updateAnime = async (id, animeData, openings, endings) => {
-    const { error: animeError } = await _supabase.from('animes').update(animeData).eq('id', id);
-    if (animeError) {
-        console.error('Error updating anime:', animeError);
+    // First, find out if this is a continuation anime
+    const { data: anime, error: fetchError } = await _supabase
+        .from('animes')
+        .select('main_anime_id')
+        .eq('id', id)
+        .single();
+
+    if (fetchError) {
+        console.error('Error fetching anime before update:', fetchError);
         return false;
     }
 
-    await _supabase.from('openings').delete().eq('anime_id', id);
-    await _supabase.from('endings').delete().eq('anime_id', id);
+    // ID for updating songs and comments is the main anime's ID, or its own if it's a main anime
+    const songUpdateId = anime.main_anime_id || id;
 
-    if (openings.length > 0) {
-        const openingsWithId = openings.map(o => ({ ...o, anime_id: id }));
+    // The animeData contains season-specific info (like day_of_week) that is safe to update on the entry itself.
+    // The UI will control what's in here (i.e., not allow editing name/comments on continuations).
+    const { error: animeError } = await _supabase.from('animes').update(animeData).eq('id', id);
+    if (animeError) {
+        console.error('Error updating anime metadata:', animeError);
+        return false;
+    }
+
+    // If we are editing the main entry, also update its comments.
+    // The UI will ensure `animeData.comments` is only present when editing a main entry.
+    if (!anime.main_anime_id && animeData.comments !== undefined) {
+        await _supabase.from('animes').update({ comments: animeData.comments }).eq('id', id);
+    }
+
+    // Now, update the songs on the correct (main) entry
+    await _supabase.from('openings').delete().eq('anime_id', songUpdateId);
+    await _supabase.from('endings').delete().eq('anime_id', songUpdateId);
+
+    if (openings && openings.length > 0) {
+        const openingsWithId = openings.map(o => ({ ...o, anime_id: songUpdateId }));
         await _supabase.from('openings').insert(openingsWithId);
     }
-    if (endings.length > 0) {
-        const endingsWithId = endings.map(e => ({ ...e, anime_id: id }));
+    if (endings && endings.length > 0) {
+        const endingsWithId = endings.map(e => ({ ...e, anime_id: songUpdateId }));
         await _supabase.from('endings').insert(endingsWithId);
     }
     return true;

--- a/index.html
+++ b/index.html
@@ -33,6 +33,9 @@
                 <button id="add-season-btn" title="Nueva Temporada">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
                 </button>
+                <button id="add-continuation-btn" title="Añadir Continuación">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.72"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.72-1.72"></path></svg>
+                </button>
                 <button id="edit-season-btn" title="Editar Temporada">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
                 </button>
@@ -67,7 +70,13 @@
         <div class="modal-content">
             <span class="close-btn">&times;</span>
             <h2>Agregar Anime</h2>
-            <input type="text" id="anime-name-input" placeholder="Nombre del Anime">
+            <div id="continuation-section" style="display: none;">
+                <label for="continuation-select">Seleccionar anime a continuar:</label>
+                <select id="continuation-select"></select>
+            </div>
+            <div id="new-anime-section">
+                <input type="text" id="anime-name-input" placeholder="Nombre del Anime">
+            </div>
             <select id="day-of-week-input">
                 <option value="Lunes">Lunes</option>
                 <option value="Martes">Martes</option>

--- a/main.js
+++ b/main.js
@@ -5,6 +5,7 @@ const state = {
     currentSeasonId: null,
     editingAnimeId: null,
     editingSeasonId: null,
+    isContinuationMode: false,
 };
 
 const ADMIN_PASSWORD = 'admin'; // NOTA: Esto es inseguro. En una app real, usar variables de entorno.
@@ -52,21 +53,61 @@ function setupEventListeners() {
     });
 
     ui.DOM.addSeasonBtn.addEventListener('click', () => ui.openModal(ui.DOM.addSeasonModal));
+
+    const prepareNewAnimeModal = () => {
+        state.isContinuationMode = false;
+        state.editingAnimeId = null;
+        ui.DOM.addAnimeModal.querySelector('h2').textContent = 'Agregar Anime';
+        ui.DOM.continuationSection.style.display = 'none';
+        ui.DOM.newAnimeSection.style.display = 'block';
+        ui.DOM.openingsList.parentElement.style.display = 'block';
+        ui.DOM.endingsList.parentElement.style.display = 'block';
+        ui.DOM.commentsInput.style.display = 'block';
+    };
+
     ui.DOM.addAnimeBtn.addEventListener('click', () => {
-        if (state.currentSeasonId) {
-            ui.openModal(ui.DOM.addAnimeModal);
-        } else {
-            alert('Por favor, crea y selecciona una temporada primero.');
+        if (!state.currentSeasonId) return alert('Por favor, crea y selecciona una temporada primero.');
+        prepareNewAnimeModal();
+        ui.openModal(ui.DOM.addAnimeModal);
+    });
+
+    ui.DOM.addContinuationBtn.addEventListener('click', async () => {
+        if (!state.currentSeasonId) return alert('Por favor, selecciona una temporada primero.');
+
+        state.isContinuationMode = true;
+        const animes = await api.getContinuableAnimes();
+
+        if (animes.length === 0) {
+            return alert('No hay animes en temporadas anteriores para continuar.');
         }
+
+        ui.DOM.addAnimeModal.querySelector('h2').textContent = 'Añadir Continuación';
+        ui.DOM.continuationSection.style.display = 'block';
+        ui.DOM.newAnimeSection.style.display = 'none';
+        ui.DOM.openingsList.parentElement.style.display = 'none';
+        ui.DOM.endingsList.parentElement.style.display = 'none';
+        ui.DOM.commentsInput.style.display = 'none';
+
+        const select = ui.DOM.continuationSelect;
+        select.innerHTML = '<option value="">Selecciona un anime...</option>';
+        animes.forEach(anime => {
+            const option = document.createElement('option');
+            option.value = anime.id;
+            option.textContent = anime.name;
+            select.appendChild(option);
+        });
+
+        ui.openModal(ui.DOM.addAnimeModal);
     });
 
     ui.DOM.closeBtns.forEach(btn => {
         btn.addEventListener('click', (e) => {
             const modal = e.target.closest('.modal');
             ui.closeModal(modal);
+            // Reset state on any modal close
             if (modal === ui.DOM.addAnimeModal) {
                 state.editingAnimeId = null;
-                // Reset form
+                state.isContinuationMode = false;
             }
             if (modal === ui.DOM.addSeasonModal) {
                 state.editingSeasonId = null;
@@ -131,33 +172,50 @@ function setupEventListeners() {
     });
 
     ui.DOM.saveAnimeBtn.addEventListener('click', async () => {
-        const name = ui.DOM.animeNameInput.value.trim();
-        if (!name) return alert('El nombre del anime no puede estar vacío.');
-
-        const animeData = {
-            name: name,
-            day_of_week: ui.DOM.dayOfWeekInput.value,
-            comments: ui.DOM.commentsInput.value.trim(),
-            season_id: state.currentSeasonId
-        };
-
-        const openings = Array.from(ui.DOM.openingsList.querySelectorAll('.song-entry')).map(entry => ({
-            jp_name: entry.querySelector('.song-jp-name').value.trim(),
-            romaji_name: entry.querySelector('.song-romaji-name').value.trim(),
-            youtube_url: entry.querySelector('.song-youtube-url').value.trim(),
-        })).filter(s => s.jp_name || s.romaji_name || s.youtube_url);
-
-        const endings = Array.from(ui.DOM.endingsList.querySelectorAll('.song-entry')).map(entry => ({
-            jp_name: entry.querySelector('.song-jp-name').value.trim(),
-            romaji_name: entry.querySelector('.song-romaji-name').value.trim(),
-            youtube_url: entry.querySelector('.song-youtube-url').value.trim(),
-        })).filter(s => s.jp_name || s.romaji_name || s.youtube_url);
-
         let success;
-        if (state.editingAnimeId) {
-            success = await api.updateAnime(state.editingAnimeId, animeData, openings, endings);
+        if (state.isContinuationMode) {
+            const select = ui.DOM.continuationSelect;
+            const main_anime_id = parseInt(select.value);
+            if (!main_anime_id) return alert('Por favor, selecciona un anime para continuar.');
+
+            const selectedOption = select.options[select.selectedIndex];
+            const animeData = {
+                name: selectedOption.textContent, // Inherit name from main anime
+                day_of_week: ui.DOM.dayOfWeekInput.value,
+                comments: '', // Comments are on the main entry
+                season_id: state.currentSeasonId,
+                main_anime_id: main_anime_id,
+            };
+            success = await api.addAnime(animeData, [], []); // No songs for continuations
         } else {
-            success = await api.addAnime(animeData, openings, endings);
+            // This is the original logic for adding a new anime or editing an existing one
+            const name = ui.DOM.animeNameInput.value.trim();
+            if (!name) return alert('El nombre del anime no puede estar vacío.');
+
+            const animeData = {
+                name: name,
+                day_of_week: ui.DOM.dayOfWeekInput.value,
+                comments: ui.DOM.commentsInput.value.trim(),
+                season_id: state.currentSeasonId
+            };
+
+            const openings = Array.from(ui.DOM.openingsList.querySelectorAll('.song-entry')).map(entry => ({
+                jp_name: entry.querySelector('.song-jp-name').value.trim(),
+                romaji_name: entry.querySelector('.song-romaji-name').value.trim(),
+                youtube_url: entry.querySelector('.song-youtube-url').value.trim(),
+            })).filter(s => s.jp_name || s.romaji_name || s.youtube_url);
+
+            const endings = Array.from(ui.DOM.endingsList.querySelectorAll('.song-entry')).map(entry => ({
+                jp_name: entry.querySelector('.song-jp-name').value.trim(),
+                romaji_name: entry.querySelector('.song-romaji-name').value.trim(),
+                youtube_url: entry.querySelector('.song-youtube-url').value.trim(),
+            })).filter(s => s.jp_name || s.romaji_name || s.youtube_url);
+
+            if (state.editingAnimeId) {
+                success = await api.updateAnime(state.editingAnimeId, animeData, openings, endings);
+            } else {
+                success = await api.addAnime(animeData, openings, endings);
+            }
         }
 
         if (success) {
@@ -165,6 +223,7 @@ function setupEventListeners() {
             ui.renderAnimes(animes);
             ui.closeModal(ui.DOM.addAnimeModal);
             state.editingAnimeId = null; // Reset editing state
+            state.isContinuationMode = false; // Reset continuation mode
         } else {
             alert(`No se pudo ${state.editingAnimeId ? 'actualizar' : 'guardar'} el anime.`);
         }
@@ -218,11 +277,25 @@ function setupEventListeners() {
         } else if (e.target.classList.contains('edit-anime-btn')) {
             const anime = await api.getAnimeDetails(animeId);
             if (anime) {
+                prepareNewAnimeModal(); // Reset modal to its default state
                 state.editingAnimeId = anime.id;
+
                 ui.DOM.addAnimeModal.querySelector('h2').textContent = 'Editar Anime';
                 ui.DOM.animeNameInput.value = anime.name;
                 ui.DOM.dayOfWeekInput.value = anime.day_of_week;
-                ui.DOM.commentsInput.value = anime.comments;
+                ui.DOM.commentsInput.value = anime.comments || '';
+
+                // Handle readonly fields for continuations
+                const isContinuation = !!anime.main_anime_id;
+                ui.DOM.animeNameInput.readOnly = isContinuation;
+                ui.DOM.commentsInput.readOnly = isContinuation;
+                if(isContinuation) {
+                    ui.DOM.animeNameInput.title = 'El nombre se hereda del anime original y no se puede cambiar aquí.';
+                    ui.DOM.commentsInput.title = 'Los comentarios se heredan del anime original y no se pueden cambiar aquí.';
+                } else {
+                    ui.DOM.animeNameInput.title = '';
+                    ui.DOM.commentsInput.title = '';
+                }
 
                 ui.DOM.openingsList.innerHTML = '';
                 if(anime.openings) {

--- a/style.css
+++ b/style.css
@@ -544,6 +544,7 @@ legend {
 
 /* Read-Only Mode Styles */
 .readonly-mode #season-manager #add-season-btn,
+.readonly-mode #season-manager #add-continuation-btn,
 .readonly-mode #season-manager #edit-season-btn,
 .readonly-mode #season-manager #delete-season-btn,
 .readonly-mode #add-anime-btn,

--- a/ui.js
+++ b/ui.js
@@ -1,10 +1,12 @@
 export const pencilIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>`;
 export const trashIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path><line x1="10" y1="11" x2="10" y2="17"></line><line x1="14" y1="11" x2="14" y2="17"></line></svg>`;
 export const youtubeIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22.54 6.42a2.78 2.78 0 0 0-1.94-2C18.88 4 12 4 12 4s-6.88 0-8.6.46a2.78 2.78 0 0 0-1.94 2A29 29 0 0 0 1 11.75a29 29 0 0 0 .46 5.33A2.78 2.78 0 0 0 3.4 19c1.72.46 8.6.46 8.6.46s6.88 0 8.6-.46a2.78 2.78 0 0 0 1.94-2 29 29 0 0 0 .46-5.25 29 29 0 0 0-.46-5.33z"></path><polygon points="9.75 15.02 15.5 11.75 9.75 8.48 9.75 15.02"></polygon></svg>`;
+export const linkIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="continuation-icon"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.72"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.72-1.72"></path></svg>`;
 
 export const DOM = {
     seasonSelector: document.getElementById('season-selector'),
     addSeasonBtn: document.getElementById('add-season-btn'),
+    addContinuationBtn: document.getElementById('add-continuation-btn'),
     editSeasonBtn: document.getElementById('edit-season-btn'),
     deleteSeasonBtn: document.getElementById('delete-season-btn'),
     animeListContainer: document.getElementById('anime-list-container'),
@@ -14,7 +16,10 @@ export const DOM = {
     closeBtns: document.querySelectorAll('.close-btn'),
     seasonNameInput: document.getElementById('season-name-input'),
     saveSeasonBtn: document.getElementById('save-season-btn'),
+    newAnimeSection: document.getElementById('new-anime-section'),
     animeNameInput: document.getElementById('anime-name-input'),
+    continuationSection: document.getElementById('continuation-section'),
+    continuationSelect: document.getElementById('continuation-select'),
     dayOfWeekInput: document.getElementById('day-of-week-input'),
     commentsInput: document.getElementById('comments-input'),
     openingsList: document.getElementById('openings-list'),
@@ -74,9 +79,10 @@ export const renderAnimes = (animes) => {
                 const endingsHTML = anime.endings && anime.endings.length > 0
                     ? anime.endings.map((en, index) => `<li class="song-item"><strong class="song-title">ED ${index + 1}:</strong><div class="song-details"><span><strong>JP:</strong> ${en.jp_name || 'N/A'}</span><span><strong>Romaji:</strong> ${en.romaji_name || 'N/A'}</span>${en.youtube_url ? `<a href="${en.youtube_url}" target="_blank" title="${en.youtube_url}" class="youtube-link">${youtubeIcon}</a>` : ''}</div></li>`).join('')
                     : '<li>N/A</li>';
+                const continuationIcon = anime.main_anime_id ? linkIcon : '';
                 animeCard.innerHTML = `
                     <div class="anime-card-header">
-                        <h4>${anime.name}</h4>
+                        <h4>${continuationIcon}${anime.name}</h4>
                         <span class="accordion-icon"></span>
                     </div>
                     <div class="anime-details">


### PR DESCRIPTION
…bugs.

Feature: Anime Continuations
- Users can now link an anime in one season to an entry in a previous season. This is for animes that span multiple cours or seasons.
- A new `main_anime_id` column in the `animes` table links continuations to their main entry.
- The UI has a new 'Add Continuation' workflow.
- When viewing or editing, shared data (name, comments, songs) is now fetched from and saved to the main anime entry, ensuring all instances are synced.
- Continuation entries in the UI are marked with a link icon.

Bug Fixes:
1.  **Anime Overwrite Bug:** Fixes an issue where editing an anime and then adding a new one would overwrite the edited entry. This was fixed by ensuring `state.editingAnimeId` is reset after a successful save.
2.  **Scroll-to-Top Button Visibility:** Fixes an issue where the scroll-to-top button was only visible to admins. The CSS rules for read-only mode were made more specific to only hide admin controls, leaving the scroll button functional for all users.