### PR TITLE
This commit fixes a bug where the Romaji names for openings and endin…

### DIFF
--- a/main.js
+++ b/main.js
@@ -300,12 +300,12 @@ function setupEventListeners() {
 
                 ui.DOM.openingsList.innerHTML = '';
                 if(anime.openings) {
-                    anime.openings.forEach(op => ui.DOM.openingsList.appendChild(ui.createSongEntryForm({ jpName: op.jp_name, romajiName: op.romaji_name, youtubeUrl: op.youtube_url })));
+                    anime.openings.forEach(op => ui.DOM.openingsList.appendChild(ui.createSongEntryForm({ jpName: op.jpName, romajiName: op.romajiName, youtubeUrl: op.youtubeUrl })));
                 }
 
                 ui.DOM.endingsList.innerHTML = '';
                 if(anime.endings) {
-                    anime.endings.forEach(en => ui.DOM.endingsList.appendChild(ui.createSongEntryForm({ jpName: en.jp_name, romajiName: en.romaji_name, youtubeUrl: en.youtube_url })));
+                    anime.endings.forEach(en => ui.DOM.endingsList.appendChild(ui.createSongEntryForm({ jpName: en.jpName, romajiName: en.romajiName, youtubeUrl: en.youtubeUrl })));
                 }
 
                 ui.openModal(ui.DOM.addAnimeModal);


### PR DESCRIPTION
…gs were not being displayed in the edit form.

The issue was caused by a mismatch between the database column names (snake_case) and the JavaScript object property names (camelCase) provided by the Supabase client library. The code was attempting to access `song.romaji_name` on the returned song objects, but the correct property name is `song.romajiName`.

The `edit-anime-btn` event handler in `main.js` has been updated to use the correct camelCase property names (`jpName`, `romajiName`, `youtubeUrl`) when populating the form.