### PR TITLE
This commit fixes a bug where song information (JP Name, Romaji, URL)…

### DIFF
--- a/main.js
+++ b/main.js
@@ -300,12 +300,12 @@ function setupEventListeners() {
 
                 ui.DOM.openingsList.innerHTML = '';
                 if(anime.openings) {
-                    anime.openings.forEach(op => ui.DOM.openingsList.appendChild(ui.createSongEntryForm({ jpName: op.jpName, romajiName: op.romajiName, youtubeUrl: op.youtubeUrl })));
+                    anime.openings.forEach(op => ui.DOM.openingsList.appendChild(ui.createSongEntryForm({ jpName: op.jp_name, romajiName: op.romaji_name, youtubeUrl: op.youtube_url })));
                 }
 
                 ui.DOM.endingsList.innerHTML = '';
                 if(anime.endings) {
-                    anime.endings.forEach(en => ui.DOM.endingsList.appendChild(ui.createSongEntryForm({ jpName: en.jpName, romajiName: en.romajiName, youtubeUrl: en.youtubeUrl })));
+                    anime.endings.forEach(en => ui.DOM.endingsList.appendChild(ui.createSongEntryForm({ jpName: en.jp_name, romajiName: en.romaji_name, youtubeUrl: en.youtube_url })));
                 }
 
                 ui.openModal(ui.DOM.addAnimeModal);


### PR DESCRIPTION
… was not loading into the edit form.

This reverts a previous incorrect fix. The issue was a misunderstanding of the data format returned by the API. The code now correctly accesses the `snake_case` properties from the song objects returned by the Supabase client (e.g., `song.romaji_name`).

The `edit-anime-btn` event handler in `main.js` has been corrected to use these `snake_case` property names when creating the song entry forms for the modal.