### PR TITLE
fix(api): Ensure romaji_name is fetched in all queries

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -31,7 +31,7 @@ export const getAnimesBySeason = async (seasonId) => {
                 // It's a continuation, fetch details from the main anime
                 const { data: mainAnime, error: mainError } = await _supabase
                     .from('animes')
-                    .select('name, comments, openings(*), endings(*)')
+                    .select('name, comments, openings(jp_name, romaji_name, youtube_url), endings(jp_name, romaji_name, youtube_url)')
                     .eq('id', anime.main_anime_id)
                     .single();
 
@@ -52,7 +52,7 @@ export const getAnimesBySeason = async (seasonId) => {
             // It's a main anime, just fetch its own songs
             const { data: songs, error: songError } = await _supabase
                 .from('animes')
-                .select('openings(*), endings(*)')
+                .select('openings(jp_name, romaji_name, youtube_url), endings(jp_name, romaji_name, youtube_url)')
                 .eq('id', anime.id)
                 .single();
 
@@ -89,7 +89,7 @@ export const getAnimeDetails = async (animeId) => {
             // It's a continuation, get shared data from main
             const { data: mainAnime, error: mainError } = await _supabase
                 .from('animes')
-                .select('name, comments, openings(*), endings(*)')
+                .select('name, comments, openings(jp_name, romaji_name, youtube_url), endings(jp_name, romaji_name, youtube_url)')
                 .eq('id', anime.main_anime_id)
                 .single();
 
@@ -109,7 +109,7 @@ export const getAnimeDetails = async (animeId) => {
             // It's a main anime, get its own songs separately and merge
             const { data: songs, error: songError } = await _supabase
                 .from('animes')
-                .select('openings(*), endings(*)')
+                .select('openings(jp_name, romaji_name, youtube_url), endings(jp_name, romaji_name, youtube_url)')
                 .eq('id', anime.id)
                 .single();
 
@@ -151,7 +151,7 @@ export const searchAnimes = async (searchTerm) => {
 
     const { data, error } = await _supabase
         .from('animes')
-        .select('*, openings(*), endings(*)')
+        .select('*, openings(jp_name, romaji_name, youtube_url), endings(jp_name, romaji_name, youtube_url)')
         .is('main_anime_id', null) // Only search against main entries to avoid duplicates
         .ilike('name', `%${searchTerm}%`);
 

--- a/styles/modals.css
+++ b/styles/modals.css
@@ -108,7 +108,16 @@
 
 #add-anime-modal fieldset {
     background-color: var(--song-item-odd-bg);
-    border: 1px dashed var(--border-color);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 1rem 1.5rem;
+    margin-bottom: 1.5rem;
+}
+
+#add-anime-modal fieldset legend {
+    font-weight: 600;
+    padding: 0 0.5rem;
+    margin-left: -0.5rem; /* Align with padding */
 }
 
 #add-anime-modal .song-entry {


### PR DESCRIPTION
This commit resolves the persistent issue of `romaji_name` not appearing in the edit modal.

The Supabase queries in `getAnimesBySeason`, `getAnimeDetails`, and `searchAnimes` have been updated to explicitly select `romaji_name` and other song fields. This guarantees the data is always available to the client.

Also improves the internal styling of the edit modal by updating the CSS for `fieldset` elements, providing a cleaner and more modern UI.