### PR TITLE
Fix layout of song entries in edit modal

### DIFF
--- a/styles/modals.css
+++ b/styles/modals.css
@@ -136,7 +136,7 @@
 #add-anime-modal .song-entry {
     display: grid;
     /* Give more weight to the name fields, less to the URL, and let the button be auto-sized. */
-    grid-template-columns: 3fr 3fr 2fr auto;
+    grid-template-columns: 1fr 1fr 1fr auto;
     gap: 1rem; /* Increased gap for better visual separation */
     align-items: center;
     background-color: var(--card-bg);


### PR DESCRIPTION
The song entry form in the edit anime modal had a grid layout that left a large empty space on wider screens.

This change adjusts the grid column distribution from '3fr 3fr 2fr auto' to '1fr 1fr 1fr auto', allowing the input fields to expand and fill the available space more evenly.

This resolves the visual bug and improves the user experience on desktop without affecting the mobile layout.