### PR TITLE
Fix grid layout for song entries in edit modal

### DIFF
--- a/styles/modals.css
+++ b/styles/modals.css
@@ -136,7 +136,7 @@
 #add-anime-modal .song-entry {
     display: grid;
     /* Give more weight to the name fields, less to the URL, and let the button be auto-sized. */
-    grid-template-columns: 1fr 1fr 1fr auto;
+    grid-template-columns: auto auto 1fr auto;
     gap: 1rem; /* Increased gap for better visual separation */
     align-items: center;
     background-color: var(--card-bg);


### PR DESCRIPTION
The song entry form in the edit anime modal had a grid layout that left a large empty space to the right of the delete button on wider screens.

This change adjusts the grid column distribution to 'auto auto 1fr auto'. This makes the first two input columns size to their content, while the third (URL) input expands to fill all remaining horizontal space. This pushes the delete button to the far right edge of its container, eliminating the empty space and creating a more balanced layout.

This resolves the visual bug based on user feedback and improves the UI on desktop screens.