### PR TITLE
feat: Fix song entry layout and improve modal styles

### DIFF
--- a/styles/modals.css
+++ b/styles/modals.css
@@ -65,13 +65,20 @@
     padding: 0.85rem;
     font-size: 1.1rem;
     font-weight: 600;
-    background-color: var(--action-primary-bg);
+    background-color: var(--action-primary-bg); /* Fallback */
+    background-image: linear-gradient(to right, var(--primary-main), var(--primary-dark));
+    border: none;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.15);
+    transition: transform 0.2s, box-shadow 0.2s;
 }
 
 .modal button#save-anime-btn:hover,
 .modal button#save-season-btn:hover,
 #login-modal button:hover {
     background-color: var(--action-primary-hover-bg);
+    background-image: linear-gradient(to right, var(--primary-dark), var(--primary-main));
+    transform: translateY(-2px);
+    box-shadow: 0 4px 10px rgba(0,0,0,0.2);
 }
 
 @keyframes fadeIn {
@@ -130,13 +137,13 @@
 
 #add-anime-modal.edit-mode fieldset {
     background-color: var(--action-edit-bg-light);
-    border: 1px solid var(--action-edit-border-light);
+    border: 2px solid var(--action-edit-color);
 }
 
 #add-anime-modal .song-entry {
     display: grid;
     /* Give more weight to the name fields, less to the URL, and let the button be auto-sized. */
-    grid-template-columns: auto auto 1fr auto;
+    grid-template-columns: 1fr 1fr auto;
     gap: 1rem; /* Increased gap for better visual separation */
     align-items: center;
     background-color: var(--card-bg);
@@ -177,18 +184,21 @@
     background-color: var(--action-add-color);
     border: none;
     color: white;
-    padding: 0.5rem 1rem;
-    border-radius: 5px;
+    padding: 0.6rem 1.2rem; /* Slightly larger padding */
+    border-radius: 6px; /* Slightly more rounded */
     cursor: pointer;
-    transition: background-color 0.2s;
+    transition: background-color 0.2s, transform 0.2s, box-shadow 0.2s;
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
-    font-weight: 500;
+    font-weight: 600; /* Bolder font */
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1); /* Add shadow */
 }
 
 .add-entry-btn:hover {
     background-color: var(--action-add-hover-bg);
+    transform: translateY(-2px); /* Add hover effect */
+    box-shadow: 0 4px 8px rgba(0,0,0,0.15);
 }
 
 .add-entry-btn svg {

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -22,7 +22,7 @@
     --action-primary-hover-bg: var(--primary-dark);
     --action-add-color: #10b981;
     --action-edit-color: #8b5cf6; /* Purple */
-    --action-edit-bg-light: rgba(139, 92, 246, 0.05);
+    --action-edit-bg-light: rgba(139, 92, 246, 0.1);
     --action-edit-border-light: rgba(139, 92, 246, 0.2);
     --action-delete-color: #ef4444;
     --action-danger-bg: #ef4444;
@@ -56,7 +56,7 @@ body.dark-mode {
 
     --action-add-color: #34d399;
     --action-edit-color: #a78bfa; /* Lighter Purple */
-    --action-edit-bg-light: rgba(167, 139, 250, 0.08);
+    --action-edit-bg-light: rgba(167, 139, 250, 0.12);
     --action-edit-border-light: rgba(167, 139, 250, 0.2);
     --action-delete-color: #f87171;
 }


### PR DESCRIPTION
This commit addresses user feedback to fix the layout of the song entry form within the edit/add modal and to improve the overall visual design.

Layout Changes:
- The grid layout for song entries has been changed to '1fr 1fr auto' as per the user's suggestion. This resolves an issue with empty space by wrapping the fourth element (the delete button) to a new line.

Visual Improvements:
- The 'Add Entry' button has been enlarged and given more visual weight with a box-shadow and hover effect.
- The main 'Save' button now features a gradient and a more prominent box-shadow.
- The distinction for 'edit mode' has been enhanced by making the fieldset border thicker and more colorful.
- The background color for 'edit mode' fieldsets has been made slightly more opaque for better contrast.

These changes result in a more polished and visually appealing user interface that aligns with the user's requests.