### PR TITLE
feat: Fix YouTube modal and add season editing

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,10 @@
         <div class="modal-content">
             <span class="close-btn">&times;</span>
             <h2>Agregar Anime</h2>
+            <div id="edit-season-section" class="form-group" style="display: none;">
+                <label for="anime-season-select">Cambiar Temporada:</label>
+                <select id="anime-season-select"></select>
+            </div>
             <div id="continuation-section" style="display: none;">
                 <label for="continuation-select">Seleccionar anime a continuar:</label>
                 <select id="continuation-select"></select>
@@ -130,10 +134,13 @@
     <!-- Modal para Video -->
     <div id="video-modal" class="modal">
         <div class="modal-content video-modal-content">
-            <span class="close-btn">&times;</span>
-            <a id="open-in-yt-link" href="#" target="_blank" title="Abrir en una nueva pestaña de YouTube" class="video-modal-action">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
-            </a>
+            <div class="video-modal-header">
+                <a id="open-in-yt-link" href="#" target="_blank" title="Abrir en una nueva pestaña de YouTube" class="video-modal-action">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
+                    <span>Abrir en YouTube</span>
+                </a>
+                <span class="close-btn">&times;</span>
+            </div>
             <div class="video-container">
                 <iframe id="youtube-iframe" width="560" height="315" src="" frameborder="0" referrerpolicy="no-referrer" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
             </div>

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -117,7 +117,7 @@ export async function handleSaveAnime() {
             name: name,
             day_of_week: ui.DOM.dayOfWeekInput.value,
             comments: ui.DOM.commentsInput.value.trim(),
-            season_id: currentSeasonId
+            season_id: editingAnimeId ? parseInt(ui.DOM.animeSeasonSelect.value) : currentSeasonId,
         };
 
         const openings = ui.getSongEntries(ui.DOM.openingsList);
@@ -183,7 +183,7 @@ async function handleEditAnime(animeId) {
     const anime = await api.getAnimeDetails(animeId);
     if (anime) {
         setState({ editingAnimeId: anime.id });
-        ui.prepareEditAnimeModal(anime);
+        await ui.prepareEditAnimeModal(anime);
         ui.openModal(ui.DOM.addAnimeModal);
     }
 }

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,3 +1,5 @@
+import { getSeasons } from './api.js';
+
 export const pencilIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>`;
 export const trashIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path><line x1="10" y1="11" x2="10" y2="17"></line><line x1="14" y1="11" x2="14" y2="17"></line></svg>`;
 export const youtubeIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22.54 6.42a2.78 2.78 0 0 0-1.94-2C18.88 4 12 4 12 4s-6.88 0-8.6.46a2.78 2.78 0 0 0-1.94 2A29 29 0 0 0 1 11.75a29 29 0 0 0 .46 5.33A2.78 2.78 0 0 0 3.4 19c1.72.46 8.6.46 8.6.46s6.88 0 8.6-.46a2.78 2.78 0 0 0 1.94-2 29 29 0 0 0 .46-5.25 29 29 0 0 0-.46-5.33z"></path><polygon points="9.75 15.02 15.5 11.75 9.75 8.48 9.75 15.02"></polygon></svg>`;
@@ -23,6 +25,8 @@ export const DOM = {
     saveSeasonBtn: document.getElementById('save-season-btn'),
     newAnimeSection: document.getElementById('new-anime-section'),
     animeNameInput: document.getElementById('anime-name-input'),
+    editSeasonSection: document.getElementById('edit-season-section'),
+    animeSeasonSelect: document.getElementById('anime-season-select'),
     continuationSection: document.getElementById('continuation-section'),
     continuationSelect: document.getElementById('continuation-select'),
     dayOfWeekInput: document.getElementById('day-of-week-input'),
@@ -253,6 +257,7 @@ export function prepareNewAnimeModal() {
     DOM.addAnimeModal.classList.remove('edit-mode');
     DOM.addAnimeModal.querySelector('h2').textContent = 'Agregar Anime';
     DOM.continuationSection.style.display = 'none';
+    DOM.editSeasonSection.style.display = 'none';
     DOM.newAnimeSection.style.display = 'block';
     DOM.openingsList.parentElement.style.display = 'block';
     DOM.endingsList.parentElement.style.display = 'block';
@@ -289,11 +294,25 @@ export function prepareContinuationModal(animes) {
     });
 }
 
-export function prepareEditAnimeModal(anime) {
+export async function prepareEditAnimeModal(anime) {
     prepareNewAnimeModal(); // Start with a clean slate
     DOM.addAnimeModal.classList.add('edit-mode');
 
     DOM.addAnimeModal.querySelector('h2').textContent = 'Editar Anime';
+
+    // --- Season Selector ---
+    DOM.editSeasonSection.style.display = 'block';
+    const seasons = await getSeasons();
+    const select = DOM.animeSeasonSelect;
+    select.innerHTML = '';
+    seasons.forEach(season => {
+        const option = document.createElement('option');
+        option.value = season.id;
+        option.textContent = season.name;
+        select.appendChild(option);
+    });
+    select.value = anime.season_id;
+    // --- End Season Selector ---
 
     // Ensure song sections are visible
     DOM.openingsList.parentElement.style.display = 'block';
@@ -306,9 +325,15 @@ export function prepareEditAnimeModal(anime) {
     const isContinuation = !!anime.main_anime_id;
     DOM.animeNameInput.readOnly = isContinuation;
     DOM.commentsInput.readOnly = isContinuation;
-     if(isContinuation) {
+    if (isContinuation) {
         DOM.animeNameInput.title = 'El nombre se hereda del anime original y no se puede cambiar aquí.';
         DOM.commentsInput.title = 'Los comentarios se heredan del anime original y no se pueden cambiar aquí.';
+        // Also disable season change for continuations as it might be confusing
+        select.disabled = true;
+        DOM.editSeasonSection.title = 'La temporada de una continuación no se puede cambiar directamente.';
+    } else {
+        select.disabled = false;
+        DOM.editSeasonSection.title = '';
     }
 
     DOM.openingsList.innerHTML = '';

--- a/styles/modals.css
+++ b/styles/modals.css
@@ -240,44 +240,33 @@
 /* Video Modal Styles */
 .video-modal-content {
     padding: 0;
-    background: black;
+    background: #000;
     max-width: 900px;
+    border-radius: 8px;
+    overflow: hidden; /* Ensures the border radius is applied to the iframe */
     border: none;
+    display: flex;
+    flex-direction: column;
 }
 
-.video-container {
-    position: relative;
-    padding-bottom: 56.25%; /* 16:9 aspect ratio */
-    height: 0;
-}
-
-.video-container iframe {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-}
-
-.video-modal-content .close-btn {
-    position: absolute;
-    top: -35px;
-    right: -35px;
-    color: white;
-    font-size: 40px;
-    opacity: 0.8;
-}
-.video-modal-content .close-btn:hover {
-    opacity: 1;
+.video-modal-header {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    padding: 0.5rem 1rem;
+    background-color: #1a1a1a;
+    gap: 1rem;
 }
 
 .video-modal-action {
-    position: absolute;
-    top: -35px;
-    right: 50px;
     color: white;
     opacity: 0.8;
     transition: opacity 0.2s;
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-right: auto; /* Pushes this element to the left */
 }
 
 .video-modal-action:hover {
@@ -286,6 +275,32 @@
 
 .video-modal-action svg {
     stroke: white;
-    width: 28px;
-    height: 28px;
+    width: 20px;
+    height: 20px;
+}
+
+.video-modal-content .close-btn {
+    color: white;
+    font-size: 35px;
+    font-weight: normal;
+    cursor: pointer;
+    line-height: 1;
+    padding: 0;
+    float: none; /* Override generic close-btn style */
+}
+
+.video-container {
+    position: relative;
+    padding-bottom: 56.25%; /* 16:9 aspect ratio */
+    height: 0;
+    width: 100%; /* Ensure it takes the full width */
+}
+
+.video-container iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: none; /* Remove any default border */
 }


### PR DESCRIPTION
This commit addresses two issues:

1.  The YouTube video modal has been improved. The close button and the "Open in YouTube" link are now placed in a header above the video player for better UI/UX, preventing them from overlapping with the video content.

2.  The anime editing functionality has been enhanced. Users can now change the season of an anime directly from the edit modal via a new dropdown menu. This dropdown is populated with all available seasons. The season change is disabled for continuation entries to maintain data integrity.