### PR TITLE
Prevent Supabase from automatically pausing

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,22 @@
+name: Supabase Keep Alive
+
+on:
+  schedule:
+    # Run at 00:00 every 3 days
+    - cron: '0 0 */3 * *'
+  # Allow manual triggering
+  workflow_dispatch:
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping Supabase Database
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+        run: |
+          # Fetching seasons data via REST API to simulate activity
+          curl -s -X GET "${SUPABASE_URL}/rest/v1/seasons?select=*&limit=1" \
+            -H "apikey: ${SUPABASE_ANON_KEY}" \
+            -H "Authorization: Bearer ${SUPABASE_ANON_KEY}"


### PR DESCRIPTION
Add a GitHub Actions workflow to periodically ping the Supabase database to prevent automatic pausing of free tier projects due to inactivity. Includes instructions for setting up secrets.

---
*PR created automatically by Jules for task [734287951327103907](https://jules.google.com/task/734287951327103907) started by @BrayanmReyes*