### PR TITLE
Fix YouTube player Error 153 in video modal

### DIFF
--- a/artists.html
+++ b/artists.html
@@ -47,7 +47,7 @@
                 <span class="close-btn">&times;</span>
             </div>
             <div class="video-container">
-                <iframe id="youtube-iframe" width="560" height="315" src="" frameborder="0" referrerpolicy="no-referrer" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                <iframe id="youtube-iframe" width="560" height="315" src="" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
             </div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
                 <span class="close-btn">&times;</span>
             </div>
             <div class="video-container">
-                <iframe id="youtube-iframe" width="560" height="315" src="" frameborder="0" referrerpolicy="no-referrer" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                <iframe id="youtube-iframe" width="560" height="315" src="" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This commit fixes the "Error 153: Error de configuración del reproductor de vídeo" encountered when trying to view YouTube videos in the modal.

The issue was caused by the `referrerpolicy="no-referrer"` attribute on the `<iframe>` elements in `index.html` and `artists.html`. YouTube's embed player requires an HTTP referer for certain domain checks and configurations to work. By removing this restrictive attribute, the browser defaults to its standard referrer policy, allowing the embedded video to load and play correctly.

---
*PR created automatically by Jules for task [5396388604048804581](https://jules.google.com/task/5396388604048804581) started by @BrayanmReyes*