### PR TITLE
Fix YouTube video player Error 153

### DIFF
--- a/artists.html
+++ b/artists.html
@@ -47,7 +47,7 @@
                 <span class="close-btn">&times;</span>
             </div>
             <div class="video-container">
-                <iframe id="youtube-iframe" width="560" height="315" src="" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                <iframe id="youtube-iframe" width="560" height="315" src="" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen referrerpolicy="strict-origin-when-cross-origin"></iframe>
             </div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
                 <span class="close-btn">&times;</span>
             </div>
             <div class="video-container">
-                <iframe id="youtube-iframe" width="560" height="315" src="" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                <iframe id="youtube-iframe" width="560" height="315" src="" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen referrerpolicy="strict-origin-when-cross-origin"></iframe>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Added `referrerpolicy="strict-origin-when-cross-origin"` to the youtube `<iframe id="youtube-iframe">` in both `index.html` and `artists.html` to fix the Youtube video player throwing Error 153.

---
*PR created automatically by Jules for task [5396388604048804581](https://jules.google.com/task/5396388604048804581) started by @BrayanmReyes*