### PR TITLE
Fix season dropdown duplication and apply modern rounded UI styling

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -269,13 +269,21 @@ export const updateSeasonNameOptions = (year, selectedSeasonId = null) => {
         return;
     }
 
+    const seenSeasons = new Set();
+
     seasonsForYear.forEach(season => {
-        const option = document.createElement('option');
-        option.value = season.id;
         // The name might be "Winter 2024", we could just display "Winter" here
         const seasonPart = season.name.split(' ').slice(0, -1).join(' ');
-        option.textContent = seasonPart || season.name;
-        DOM.seasonNameSelector.appendChild(option);
+        const displayName = seasonPart || season.name;
+
+        // Deduplicate
+        if (!seenSeasons.has(displayName)) {
+            seenSeasons.add(displayName);
+            const option = document.createElement('option');
+            option.value = season.id;
+            option.textContent = displayName;
+            DOM.seasonNameSelector.appendChild(option);
+        }
     });
 
     if (selectedSeasonId) {

--- a/styles/style.css
+++ b/styles/style.css
@@ -124,11 +124,11 @@ main {
     display: flex;
     align-items: center;
     gap: 1rem;
-    padding: 0.75rem 1rem;
+    padding: 0.75rem 1.5rem;
     background-color: var(--card-bg);
-    border-radius: 12px;
+    border-radius: 20px;
     margin-bottom: 2rem;
-    box-shadow: 0 2px 4px var(--shadow-color);
+    box-shadow: 0 4px 6px var(--shadow-color);
 }
 
 #season-manager h2 {
@@ -729,16 +729,17 @@ legend {
     -moz-appearance: none;
     background-image: url('data:image/svg+xml;utf8,<svg fill="%23ffffff" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M7 10l5 5 5-5z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
     background-repeat: no-repeat;
-    background-position: right 10px top 50%;
-    padding-right: 30px;
+    background-position: right 15px top 50%;
+    padding-right: 40px;
     background-color: var(--card-bg);
     color: var(--text-color);
     border: 1px solid var(--border-color);
-    border-radius: 8px;
+    border-radius: 20px;
     font-size: 1rem;
-    padding: 0.75rem 1rem;
+    padding: 0.75rem 1.5rem;
     cursor: pointer;
     transition: border-color 0.2s, box-shadow 0.2s;
+    box-shadow: 0 2px 4px var(--shadow-color);
 }
 
 .season-selectors select:hover {


### PR DESCRIPTION
This submission resolves the issue where duplicate season names (like "Spring") appeared multiple times in the season dropdown menu. It also fulfills the request to modernize the UI for these elements by giving them a more rounded, pill-shaped aesthetic.

---
*PR created automatically by Jules for task [10300648951130133389](https://jules.google.com/task/10300648951130133389) started by @BrayanmReyes*