### PR TITLE
Fix Supabase auto-pausing issue

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -16,13 +16,13 @@ jobs:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
         run: |
-          # Fetching seasons data via REST API to simulate activity
-          response=$(curl -s -w "%{http_code}" -o /dev/null -X GET "${SUPABASE_URL}/rest/v1/seasons?select=*&limit=1" \
-            -H "apikey: ${SUPABASE_ANON_KEY}" \
-            -H "Authorization: Bearer ${SUPABASE_ANON_KEY}")
+          # Pinging the Supabase Auth health endpoint to simulate activity and prevent auto-pausing.
+          # This is a safe and recommended way to keep the project active without mutating data.
+          response=$(curl -s -w "%{http_code}" -o /dev/null -X GET "${SUPABASE_URL}/auth/v1/health" \
+            -H "apikey: ${SUPABASE_ANON_KEY}")
 
           if [ "$response" -eq 200 ]; then
-            echo "Supabase pinged successfully! Status: $response"
+            echo "Supabase Auth health endpoint pinged successfully! Status: $response"
           else
             echo "Failed to ping Supabase. Status: $response"
             exit 1


### PR DESCRIPTION
Update keep-alive action to safely prevent Supabase from pausing by pinging the auth health endpoint.

---
*PR created automatically by Jules for task [1265087206845169771](https://jules.google.com/task/1265087206845169771) started by @BrayanmReyes*